### PR TITLE
Drop geos fork

### DIFF
--- a/api/types/tilerequest.go
+++ b/api/types/tilerequest.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-nationalgrid"
+	"github.com/twpayne/go-geos"
 )
 
 type TileRequest struct {

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/lib/pq v1.10.7
 	github.com/llgcode/draw2d v0.0.0-20210904075650-80aa0a2a901d
 	github.com/mattn/go-sqlite3 v1.14.16
-	github.com/rockwell-uk/go-geom v0.0.0-20230120105324-232da3bff8b8
-	github.com/rockwell-uk/go-geos v0.0.0-20230120105117-162e1aadd9ec
+	github.com/rockwell-uk/go-geom v0.0.0-20230123183838-e0652ede5fd1
 	github.com/rockwell-uk/go-logger v0.0.0-20230120103407-f3045e8aa9ba
-	github.com/rockwell-uk/go-nationalgrid v0.0.0-20230120105807-2b1816c187d1
-	github.com/rockwell-uk/go-text v0.0.0-20230120105537-3697b0562f5f
+	github.com/rockwell-uk/go-nationalgrid v0.0.0-20230123194113-ce6d74862623
+	github.com/rockwell-uk/go-text v0.0.0-20230123194145-3c8beadd6d47
 	github.com/rockwell-uk/go-utils v0.0.0-20230120103952-f9b372a60411
+	github.com/twpayne/go-geos v0.8.0
 	golang.org/x/image v0.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
@@ -15,7 +16,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/cli v20.10.14+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.16+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.16+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
@@ -36,6 +39,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
@@ -56,8 +60,10 @@ github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
 github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
+github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
@@ -73,14 +79,18 @@ github.com/rockwell-uk/csync v0.0.0-20230120102944-9cfc4a9dc1c8 h1:Y5arn26UlT+cw
 github.com/rockwell-uk/csync v0.0.0-20230120102944-9cfc4a9dc1c8/go.mod h1:0girQxy6syMJ1NnMQEAbxdb/FY7kycJDeZDHVuJAjKk=
 github.com/rockwell-uk/go-geom v0.0.0-20230120105324-232da3bff8b8 h1:S+l+smGzTwkUiU8i6pfMsAX1DKFOi79sakBfrqqrC+M=
 github.com/rockwell-uk/go-geom v0.0.0-20230120105324-232da3bff8b8/go.mod h1:U+Gedb4qmHLBFvrHgav6EHoBPL50ZE4T1TsJLwzzBQo=
-github.com/rockwell-uk/go-geos v0.0.0-20230120105117-162e1aadd9ec h1:3raslXMmyrjRyGFjjOGjVI55Y2ojo0bZ0sWHGxvVHq4=
-github.com/rockwell-uk/go-geos v0.0.0-20230120105117-162e1aadd9ec/go.mod h1:lakRLu5rHTiaVUJTZ8NJ9Gt2V4YKco1ep6SQxo5R8rw=
+github.com/rockwell-uk/go-geom v0.0.0-20230123183838-e0652ede5fd1 h1:LmRvJ3SIGtn5/bBN6v+onGjKVj0DzqtBw4ZFfroi0rE=
+github.com/rockwell-uk/go-geom v0.0.0-20230123183838-e0652ede5fd1/go.mod h1:NxIPnJ43LTEjJxKo6qiqMhoQ6d5J7HkiEudKfMpa1/U=
 github.com/rockwell-uk/go-logger v0.0.0-20230120103407-f3045e8aa9ba h1:TX0zqt8i3cNTbegllHwVFVmEMVZu+Sh0iWb2y0KgubI=
 github.com/rockwell-uk/go-logger v0.0.0-20230120103407-f3045e8aa9ba/go.mod h1:c7krTa0/VvQN3QT8mfVhHSdCmsULVZBUBUNmVp2jpyo=
 github.com/rockwell-uk/go-nationalgrid v0.0.0-20230120105807-2b1816c187d1 h1:8IVJCT2KEs6ZeRcZuUWqG8EMAdf1OGEBH64ik411wfc=
 github.com/rockwell-uk/go-nationalgrid v0.0.0-20230120105807-2b1816c187d1/go.mod h1:l+MYYHDlSHoLKn5VGTxd3V6a7FodYffL8wvenpQkQtU=
+github.com/rockwell-uk/go-nationalgrid v0.0.0-20230123194113-ce6d74862623 h1:MckXQ8jScwLq4PP4Jo8W+NiLbr25xOE/m0WtjBsqN5Y=
+github.com/rockwell-uk/go-nationalgrid v0.0.0-20230123194113-ce6d74862623/go.mod h1:fySNjWMxcuca56LWIA80FGNJwcYa8r6ioReYHqyC2KE=
 github.com/rockwell-uk/go-text v0.0.0-20230120105537-3697b0562f5f h1:4FIXpQ/Lp/2gdkBBsjKZXEfitqUYmzeQfrkrIsqhsck=
 github.com/rockwell-uk/go-text v0.0.0-20230120105537-3697b0562f5f/go.mod h1:rcGxZlKSdRyd0NcWN3S1m9V1jRsYHkwR3HuQhOnm9x4=
+github.com/rockwell-uk/go-text v0.0.0-20230123194145-3c8beadd6d47 h1:nIt+2hJkkUljAehuQstN73FSjuC3ChUYZTYu7nv84W8=
+github.com/rockwell-uk/go-text v0.0.0-20230123194145-3c8beadd6d47/go.mod h1:a021D48+TGxOfZG8wmLifAaReunP3Akz/61WgI3H+VU=
 github.com/rockwell-uk/go-utils v0.0.0-20230120103952-f9b372a60411 h1:sfRbTsWHnQJEBmUXjb9Cmo6lLYO+G4Vt6MAzuwWTy/U=
 github.com/rockwell-uk/go-utils v0.0.0-20230120103952-f9b372a60411/go.mod h1:cw512fQnknLjwrrB74vz3G/62ieP9Sg3JIST9rm0EXA=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -99,12 +109,15 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/twpayne/go-geos v0.8.0 h1:MoH6uT/NXNnekuxOrREqIL1FIiF5l3KEMFggr7+7/eo=
+github.com/twpayne/go-geos v0.8.0/go.mod h1:ghmhzeDJuLrFJFvOXUbn+sjPukdKYh11fxaGVq3e7Hk=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/wroge/wgs84 v1.1.6 h1:jgG9farIi5nPhhnyZ95DCPLV4sRka+Ijp0JlsXQcz+Q=
 github.com/wroge/wgs84 v1.1.6/go.mod h1:PzgJNcWAjKvdqgO1LAQotG+ALP0d1c4A6Ww5AwqJovM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -127,6 +140,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -144,6 +158,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -174,7 +189,9 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=

--- a/layerdata/service.go
+++ b/layerdata/service.go
@@ -9,10 +9,10 @@ import (
 	"go-uk-maps/api/types"
 	"go-uk-maps/database"
 
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-logger/logger"
 	"github.com/rockwell-uk/go-nationalgrid"
 	"github.com/rockwell-uk/go-utils/sliceutils"
+	"github.com/twpayne/go-geos"
 )
 
 var (

--- a/layerdata/service_test.go
+++ b/layerdata/service_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/llgcode/draw2d/draw2dimg"
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-nationalgrid"
+	"github.com/twpayne/go-geos"
 )
 
 func TestIsInViewPolygonsMix(t *testing.T) {
@@ -196,7 +196,7 @@ func drawImage(name string, a, b *geos.Geom) error {
 
 	_type := b.TypeID()
 
-	if _type == geos.LineStringTypeID {
+	if _type == geos.TypeIDLineString {
 		err = geom.DrawLine(gc, a, thickness, fillColor, strokeWidth, strokeColor, scale)
 		if err != nil {
 			return err
@@ -206,7 +206,7 @@ func drawImage(name string, a, b *geos.Geom) error {
 			return err
 		}
 	}
-	if _type == geos.PolygonTypeID {
+	if _type == geos.TypeIDPolygon {
 		err = geom.DrawPolygon(gc, a, fillColor, strokeColor, strokeWidth, scale)
 		if err != nil {
 			return err

--- a/makeimage/decisioning.go
+++ b/makeimage/decisioning.go
@@ -8,9 +8,9 @@ import (
 	"go-uk-maps/makeimage/types"
 
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-logger/logger"
 	"github.com/rockwell-uk/go-text/text"
+	"github.com/twpayne/go-geos"
 )
 
 const (

--- a/makeimage/draw_geom.go
+++ b/makeimage/draw_geom.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/llgcode/draw2d/draw2dimg"
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-logger/logger"
+	"github.com/twpayne/go-geos"
 )
 
 func drawLayerGeometries(gc *draw2dimg.GraphicContext, mg types.MapLayerGeometries, scale func(x, y float64) (float64, float64)) error {
@@ -55,22 +55,22 @@ func DrawGeom(gc *draw2dimg.GraphicContext, mg types.MapGeom, scale func(x, y fl
 				fmt.Sprintf("type %+v [%+v] %+v %+v\n", _type, mg.DataType, mg.FillCol, mg.Thickness),
 			)
 			switch _type {
-			case geos.PointTypeID:
+			case geos.TypeIDPoint:
 				err := geom.DrawPoint(gc, g, mg.Radius, mg.FillCol, mg.Thickness, mg.LineCol, scale)
 				if err != nil {
 					return err
 				}
-			case geos.LineStringTypeID, geos.LinearRingTypeID:
+			case geos.TypeIDLineString, geos.TypeIDLinearRing:
 				err := geom.DrawLine(gc, g, mg.Thickness, mg.FillCol, mg.StrokeWidth, mg.LineCol, scale)
 				if err != nil {
 					return err
 				}
-			case geos.PolygonTypeID:
+			case geos.TypeIDPolygon:
 				err := geom.DrawPolygon(gc, g, mg.FillCol, mg.LineCol, mg.Thickness, scale)
 				if err != nil {
 					return err
 				}
-			case geos.MultiPointTypeID, geos.MultiLineStringTypeID, geos.MultiPolygonTypeID, geos.GeometryCollectionTypeID:
+			case geos.TypeIDMultiPoint, geos.TypeIDMultiLineString, geos.TypeIDMultiPolygon, geos.TypeIDGeometryCollection:
 				n := g.NumGeometries()
 				var subgeoms []*geos.Geom
 				for i := 0; i < n; i++ {

--- a/makeimage/prepare_artifacts.go
+++ b/makeimage/prepare_artifacts.go
@@ -7,7 +7,7 @@ import (
 	"go-uk-maps/makeimage/types"
 
 	"github.com/llgcode/draw2d/draw2dimg"
-	"github.com/rockwell-uk/go-geos"
+	"github.com/twpayne/go-geos"
 
 	"golang.org/x/image/draw"
 )
@@ -43,7 +43,7 @@ func prepareLayerArtifacts(gc *draw2dimg.GraphicContext, m draw.Image, l *types.
 
 func artifactFromLayerData(l *types.ImageLayer, ld layerdata.LayerData) (types.LayerArtifact, error) {
 
-	var geomType geos.GeometryTypeID
+	var geomType geos.TypeID
 
 	geom, err := gctx.NewGeomFromWKT(ld.WKT.String)
 	if err != nil {

--- a/makeimage/prepare_geom.go
+++ b/makeimage/prepare_geom.go
@@ -9,7 +9,7 @@ import (
 
 	"go-uk-maps/makeimage/types"
 
-	"github.com/rockwell-uk/go-geos"
+	"github.com/twpayne/go-geos"
 
 	"golang.org/x/image/draw"
 )
@@ -71,13 +71,13 @@ func prepareGeom(m draw.Image, l *types.ImageLayer, assetsAdded types.AssetsAdde
 		}
 
 		switch gtype {
-		case geos.PointTypeID:
+		case geos.TypeIDPoint:
 			l.Geometries.Points[dataType] = append(l.Geometries.Points[dataType], mg)
-		case geos.LineStringTypeID, geos.LinearRingTypeID:
+		case geos.TypeIDLineString, geos.TypeIDLinearRing:
 			l.Geometries.Lines[dataType] = append(l.Geometries.Lines[dataType], mg)
-		case geos.PolygonTypeID:
+		case geos.TypeIDPolygon:
 			l.Geometries.Polygons[dataType] = append(l.Geometries.Polygons[dataType], mg)
-		case geos.MultiPointTypeID, geos.MultiLineStringTypeID, geos.MultiPolygonTypeID, geos.GeometryCollectionTypeID:
+		case geos.TypeIDMultiPoint, geos.TypeIDMultiLineString, geos.TypeIDMultiPolygon, geos.TypeIDGeometryCollection:
 			l.Geometries.Multi[dataType] = append(l.Geometries.Multi[dataType], mg)
 		default:
 			return map[types.FeatCode]map[types.LabelType]map[string]types.ImageAsset{}, fmt.Errorf("unknown geometry type %v", gtype)

--- a/makeimage/prepare_label.go
+++ b/makeimage/prepare_label.go
@@ -3,8 +3,8 @@ package makeimage
 import (
 	"go-uk-maps/makeimage/types"
 
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-text/fonts"
+	"github.com/twpayne/go-geos"
 
 	"github.com/llgcode/draw2d/draw2dimg"
 )
@@ -59,7 +59,7 @@ func prepareLabel(gc *draw2dimg.GraphicContext, l *types.ImageLayer, a types.Lay
 		ShouldSplitFn: types.ShouldSplit,
 	}
 
-	if _type == geos.PointTypeID {
+	if _type == geos.TypeIDPoint {
 
 		// first element of LabelText is DISTNAME
 		label, err := GetLabelText(a.LabelText, a.LabelFieldNames[0])
@@ -104,7 +104,7 @@ func prepareLabel(gc *draw2dimg.GraphicContext, l *types.ImageLayer, a types.Lay
 		}
 	}
 
-	if _type == geos.MultiLineStringTypeID || _type == geos.LineStringTypeID {
+	if _type == geos.TypeIDMultiLineString || _type == geos.TypeIDLineString {
 
 		if dataType == types.LINE {
 

--- a/makeimage/service.go
+++ b/makeimage/service.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/llgcode/draw2d/draw2dimg"
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-logger/logger"
+	"github.com/twpayne/go-geos"
 )
 
 var (

--- a/makeimage/test/maplabel_draw_test.go
+++ b/makeimage/test/maplabel_draw_test.go
@@ -8,8 +8,8 @@ import (
 	"go-uk-maps/colours"
 	"go-uk-maps/makeimage/types"
 
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-text/fonts"
+	"github.com/twpayne/go-geos"
 
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dimg"

--- a/makeimage/test/roadlines_test.go
+++ b/makeimage/test/roadlines_test.go
@@ -15,8 +15,8 @@ import (
 	"go-uk-maps/makeimage/types"
 
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-text/fonts"
+	"github.com/twpayne/go-geos"
 
 	"github.com/llgcode/draw2d"
 	"github.com/llgcode/draw2d/draw2dimg"
@@ -159,7 +159,7 @@ func TestLineTest(t *testing.T) {
 			ID:         strconv.Itoa(id),
 			LayerType:  "lines_test",
 			FeatCode:   featCode,
-			GeomType:   geos.LineStringTypeID,
+			GeomType:   geos.TypeIDLineString,
 			ShapeType:  shapeType,
 			RenderType: renderType,
 			LabelFieldNames: []string{

--- a/makeimage/test/text_along_line_test.go
+++ b/makeimage/test/text_along_line_test.go
@@ -106,11 +106,7 @@ func TestGetLineData(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		scaledLineCoords, err := text.GetMultiLineStringCoords(tl)
-		if err != nil {
-			t.Fatal(err)
-		}
-		scaled := text.GetLineData(scaledLineCoords)
+		scaled := text.GetLineData(*geom.GetPoints(tl))
 
 		// set the origin to the same point as the blue and green line start from
 		origin := []float64{

--- a/makeimage/types/layer.go
+++ b/makeimage/types/layer.go
@@ -3,7 +3,7 @@ package types
 import (
 	"image/color"
 
-	"github.com/rockwell-uk/go-geos"
+	"github.com/twpayne/go-geos"
 )
 
 type LabelType int
@@ -25,7 +25,7 @@ type LayerArtifact struct {
 	ID                      string
 	LayerType               string
 	FeatCode                FeatCode
-	GeomType                geos.GeometryTypeID
+	GeomType                geos.TypeID
 	Geometry                *geos.Geom
 	ShapeType               ShapeType
 	RenderType              RenderType

--- a/makeimage/types/maplabel.go
+++ b/makeimage/types/maplabel.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"github.com/rockwell-uk/go-geom/geom"
-	"github.com/rockwell-uk/go-geos"
 	"github.com/rockwell-uk/go-text/fonts"
 	"github.com/rockwell-uk/go-text/text"
+	"github.com/twpayne/go-geos"
 
 	"github.com/llgcode/draw2d/draw2dimg"
 )


### PR DESCRIPTION
Now that the Simplify method has been merged and tagged (https://github.com/twpayne/go-geos/blob/master/geommethods.go#L552), and it has become clear now that the GetPoint functionality belongs outside of the go-geos library, we can now refactor in order to drop the fork